### PR TITLE
chore: default android watch script to Expo Go

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -12,7 +12,7 @@
     "build:web": "npm run prebuild:common && expo export --platform=web",
     "watch:common": "shadow-cljs watch app",
     "watch:web": "expo start --web",
-    "watch:android:expo": "expo run:android",
+    "watch:android:expo": "expo start --android",
     "dev-test-android-build": "react-native bundle --dev false --platform android --entry-file app/index.js --bundle-output ./android/app/src/main/assets/index.android.bundle --assets-dest ./android/app/src/main/res/",
     "dev-test-android-run": "./gradlew assembleDebug",
     "android": "expo run:android",


### PR DESCRIPTION
We're currently working in the constraints of Expo Go's supported native modules, and Expo Go is significantly faster than Development Build.

This change drops build times from up to ~20 minutes to just a minute

Signed-off-by: Rifa Achrinza <25147899+achrinza@users.noreply.github.com>
