### PR TITLE
chore: force `lf` line endings in Git

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf


### PR DESCRIPTION
This should cause silent conversion of CRLF to LF line endings, ensuring consistency between *NIX and Windows.

Signed-off-by: Rifa Achrinza <25147899+achrinza@users.noreply.github.com>
