### PR TITLE
fix: change links only under android specific directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "prepare": "husky",
     "reset-project": "node ./scripts/reset-project.js",
     "build:binary-images": "node ./scripts/generate-binary-images.mjs",
-    "android:build-article-assets": "mkdir android/app/src/main/assets && cp -r assets/articleAssets android/app/src/main/assets && find -iname '*.html' -type f | xargs -I{} sed -i -e 's@src=\"../../assets@src=\"file:///android_asset@' -e 's@src=\"assets@src=\"file:///android_asset@' '{}'",
+    "android:build-article-assets": "mkdir android/app/src/main/assets && cp -r assets/articleAssets android/app/src/main/assets && cd android/app/src/main/assets && find -iname '*.html' -type f | xargs -I{} sed -i -e 's@src=\"../../assets@src=\"file:///android_asset@' -e 's@src=\"assets@src=\"file:///android_asset@' '{}'",
     "prebuild:common": "npm run build:binary-images",
     "preprebuild:android": "npm run prebuild:common",
     "prebuild:android": "expo prebuild --clean --platform=android && npm run android:build-article-assets",


### PR DESCRIPTION
This ensures that the default assets directory does not have its links overridden by android specific links, enabling proper links for iOS.